### PR TITLE
Fix naming inconsistency

### DIFF
--- a/csen/csen.student.base/config.intgemm8bit.yml
+++ b/csen/csen.student.base/config.intgemm8bit.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.bin
+  - model.intgemm.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.base/config.intgemm8bitalpha.yml
+++ b/csen/csen.student.base/config.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.base/config.yml
+++ b/csen/csen.student.base/config.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.npz
+  - model.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.base/server.intgemm8bitalpha.yml
+++ b/csen/csen.student.base/server.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.base/speed.cpu.intgemm8bit.sh
+++ b/csen/csen.student.base/speed.cpu.intgemm8bit.sh
@@ -7,14 +7,14 @@ TRG=en
 
 mkdir -p speed
 
-test -e model.8bit-finetuned.intgemm8.bin || $MARIAN/marian-conv -f model.8bit-finetuned.npz -t model.8bit-finetuned.intgemm8.bin --gemm-type intgemm8
+test -e model.intgemm.bin || $MARIAN/marian-conv -f model.npz -t model.intgemm.bin --gemm-type intgemm8
 
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18
 do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/csen.student.base/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/csen.student.base/speed.cpu.intgemm8bitalpha.sh
@@ -9,18 +9,18 @@ mkdir -p speed
 
 ~/.local/bin/sacrebleu -t wmt18 -l $SRC-$TRG --echo src > speed/newstest2018.$SRC
 
-if [ ! -f model.8bit-finetuned.intgemm8.alphas.bin ]; then
+if [ ! -f model.intgemm.alphas.bin ]; then
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+test -e model.alphas.npz || $MARIAN/marian-decoder $@ \
+    --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
     --quiet --quiet-translation --log speed/cpu.newstest2018.log --dump-quantmult  2> quantmults
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.8bit-finetuned.npz model.8bit-finetuned.alphas.npz
+test -e model.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.npz model.alphas.npz
 
-test -e model.8bit-finetuned.intgemm8.alphas.bin || $MARIAN/marian-conv -f model.8bit-finetuned.alphas.npz -t model.8bit-finetuned.intgemm8.alphas.bin --gemm-type intgemm8
+test -e model.intgemm.alphas.bin || $MARIAN/marian-conv -f model.alphas.npz -t model.intgemm.alphas.bin --gemm-type intgemm8
 
 fi
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/csen.student.base/speed.cpu.sh
+++ b/csen/csen.student.base/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/csen.student.tiny11/config.intgemm8bit.yml
+++ b/csen/csen.student.tiny11/config.intgemm8bit.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.bin
+  - model.intgemm.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.tiny11/config.intgemm8bitalpha.yml
+++ b/csen/csen.student.tiny11/config.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.tiny11/config.yml
+++ b/csen/csen.student.tiny11/config.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.npz
+  - model.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.tiny11/server.intgemm8bitalpha.yml
+++ b/csen/csen.student.tiny11/server.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/csen.student.tiny11/speed.cpu.intgemm8bit.sh
+++ b/csen/csen.student.tiny11/speed.cpu.intgemm8bit.sh
@@ -7,14 +7,14 @@ TRG=en
 
 mkdir -p speed
 
-test -e model.8bit-finetuned.intgemm8.bin || $MARIAN/marian-conv -f model.8bit-finetuned.npz -t model.8bit-finetuned.intgemm8.bin --gemm-type intgemm8
+test -e model.intgemm.bin || $MARIAN/marian-conv -f model.npz -t model.intgemm.bin --gemm-type intgemm8
 
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18
 do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/csen.student.tiny11/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/csen.student.tiny11/speed.cpu.intgemm8bitalpha.sh
@@ -9,18 +9,18 @@ mkdir -p speed
 
 ~/.local/bin/sacrebleu -t wmt18 -l $SRC-$TRG --echo src > speed/newstest2018.$SRC
 
-if [ ! -f model.8bit-finetuned.intgemm8.alphas.bin ]; then
+if [ ! -f model.intgemm.alphas.bin ]; then
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+test -e model.alphas.npz || $MARIAN/marian-decoder $@ \
+    --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
     --quiet --quiet-translation --log speed/cpu.newstest2018.log --dump-quantmult  2> quantmults
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.8bit-finetuned.npz model.8bit-finetuned.alphas.npz
+test -e model.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.npz model.alphas.npz
 
-test -e model.8bit-finetuned.intgemm8.alphas.bin || $MARIAN/marian-conv -f model.8bit-finetuned.alphas.npz -t model.8bit-finetuned.intgemm8.alphas.bin --gemm-type intgemm8
+test -e model.intgemm.alphas.bin || $MARIAN/marian-conv -f model.alphas.npz -t model.intgemm.alphas.bin --gemm-type intgemm8
 
 fi
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/csen.student.tiny11/speed.cpu.sh
+++ b/csen/csen.student.tiny11/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/download-models.sh
+++ b/csen/download-models.sh
@@ -13,6 +13,12 @@ do
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.gz
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.bin
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.spm
+        # rename files for consistency
+		mv model.8bit-finetuned.npz model.npz
+        mv model.8bit-finetuned.alphas.npz model.alphas.npz
+		mv model.8bit-finetuned.intgemm8.bin model.intgemm.bin
+		mv model.8bit-finetuned.intgemm8.alphas.bin model.intgemm.alphas.bin
+		mv vocab.spm vocab.csen.spm
 		cd ..
 	done
 done
@@ -28,6 +34,8 @@ do
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.npz.best-bleu-detok.npz
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.gz
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.spm
+		# rename files for consistency
+		mv vocab.spm vocab.csen.spm
 		cd ..
 	done
 done

--- a/csen/download-models.sh
+++ b/csen/download-models.sh
@@ -6,19 +6,13 @@ do
 	do
 		mkdir -p $lang.student.$model
 		cd $lang.student.$model
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.8bit-finetuned.npz
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.8bit-finetuned.alphas.npz
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.8bit-finetuned.intgemm8.bin
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.8bit-finetuned.intgemm8.alphas.bin
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.npz
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.alphas.npz
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.intgemm.bin
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.intgemm.alphas.bin
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.gz
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.bin
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.spm
-        # rename files for consistency
-		mv model.8bit-finetuned.npz model.npz
-        mv model.8bit-finetuned.alphas.npz model.alphas.npz
-		mv model.8bit-finetuned.intgemm8.bin model.intgemm.bin
-		mv model.8bit-finetuned.intgemm8.alphas.bin model.intgemm.alphas.bin
-		mv vocab.spm vocab.csen.spm
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.csen.spm
 		cd ..
 	done
 done
@@ -33,9 +27,7 @@ do
 		cd $lang.student.$model
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/model.npz.best-bleu-detok.npz
 		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/lex.s2t.gz
-		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.spm
-		# rename files for consistency
-		mv vocab.spm vocab.csen.spm
+		wget -nc http://data.statmt.org/bergamot/models/8bit-students/$lang/$model/vocab.csen.spm
 		cd ..
 	done
 done

--- a/csen/encs.student.base/config.intgemm8bit.yml
+++ b/csen/encs.student.base/config.intgemm8bit.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.bin
+  - model.intgemm.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.base/config.intgemm8bitalpha.yml
+++ b/csen/encs.student.base/config.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.base/config.yml
+++ b/csen/encs.student.base/config.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.npz
+  - model.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.base/server.intgemm8bitalpha.yml
+++ b/csen/encs.student.base/server.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.base/speed.cpu.intgemm8bit.sh
+++ b/csen/encs.student.base/speed.cpu.intgemm8bit.sh
@@ -7,14 +7,14 @@ TRG=cs
 
 mkdir -p speed
 
-test -e model.8bit-finetuned.intgemm8.bin || $MARIAN/marian-conv -f model.8bit-finetuned.npz -t model.8bit-finetuned.intgemm8.bin --gemm-type intgemm8
+test -e model.intgemm.bin || $MARIAN/marian-conv -f model.npz -t model.intgemm.bin --gemm-type intgemm8
 
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18 wmt19
 do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/encs.student.base/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/encs.student.base/speed.cpu.intgemm8bitalpha.sh
@@ -9,18 +9,18 @@ mkdir -p speed
 
 ~/.local/bin/sacrebleu -t wmt18 -l $SRC-$TRG --echo src > speed/newstest2018.$SRC
 
-if [ ! -f model.8bit-finetuned.intgemm8.alphas.bin ]; then
+if [ ! -f model.intgemm.alphas.bin ]; then
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+test -e model.alphas.npz || $MARIAN/marian-decoder $@ \
+    --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
     --quiet --quiet-translation --log speed/cpu.newstest2018.log --dump-quantmult  2> quantmults
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.8bit-finetuned.npz model.8bit-finetuned.alphas.npz
+test -e model.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.npz model.alphas.npz
 
-test -e model.8bit-finetuned.intgemm8.alphas.bin || $MARIAN/marian-conv -f model.8bit-finetuned.alphas.npz -t model.8bit-finetuned.intgemm8.alphas.bin --gemm-type intgemm8
+test -e model.intgemm.alphas.bin || $MARIAN/marian-conv -f model.alphas.npz -t model.intgemm.alphas.bin --gemm-type intgemm8
 
 fi
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18 wmt19
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/encs.student.base/speed.cpu.sh
+++ b/csen/encs.student.base/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/encs.student.tiny11/config.intgemm8bit.yml
+++ b/csen/encs.student.tiny11/config.intgemm8bit.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.bin
+  - model.intgemm.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.tiny11/config.intgemm8bitalpha.yml
+++ b/csen/encs.student.tiny11/config.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.tiny11/config.yml
+++ b/csen/encs.student.tiny11/config.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.npz
+  - model.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.tiny11/server.intgemm8bitalpha.yml
+++ b/csen/encs.student.tiny11/server.intgemm8bitalpha.yml
@@ -1,9 +1,9 @@
 relative-paths: true
 models:
-  - model.8bit-finetuned.intgemm8.alphas.bin
+  - model.intgemm.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 shortlist:
     - lex.s2t.gz
     - 50

--- a/csen/encs.student.tiny11/speed.cpu.intgemm8bit.sh
+++ b/csen/encs.student.tiny11/speed.cpu.intgemm8bit.sh
@@ -7,14 +7,14 @@ TRG=cs
 
 mkdir -p speed
 
-test -e model.8bit-finetuned.intgemm8.bin || $MARIAN/marian-conv -f model.8bit-finetuned.npz -t model.8bit-finetuned.intgemm8.bin --gemm-type intgemm8
+test -e model.intgemm.bin || $MARIAN/marian-conv -f model.npz -t model.intgemm.bin --gemm-type intgemm8
 
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18 wmt19
 do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/encs.student.tiny11/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/encs.student.tiny11/speed.cpu.intgemm8bitalpha.sh
@@ -9,18 +9,18 @@ mkdir -p speed
 
 ~/.local/bin/sacrebleu -t wmt18 -l $SRC-$TRG --echo src > speed/newstest2018.$SRC
 
-if [ ! -f model.8bit-finetuned.intgemm8.alphas.bin ]; then
+if [ ! -f model.intgemm.alphas.bin ]; then
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+test -e model.alphas.npz || $MARIAN/marian-decoder $@ \
+    --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
     --quiet --quiet-translation --log speed/cpu.newstest2018.log --dump-quantmult  2> quantmults
 
-test -e model.8bit-finetuned.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.8bit-finetuned.npz model.8bit-finetuned.alphas.npz
+test -e model.alphas.npz || $MARIAN/../scripts/alphas/extract_stats.py quantmults model.npz model.alphas.npz
 
-test -e model.8bit-finetuned.intgemm8.alphas.bin || $MARIAN/marian-conv -f model.8bit-finetuned.alphas.npz -t model.8bit-finetuned.intgemm8.alphas.bin --gemm-type intgemm8
+test -e model.intgemm.alphas.bin || $MARIAN/marian-conv -f model.alphas.npz -t model.intgemm.alphas.bin --gemm-type intgemm8
 
 fi
 for wmt in wmt14 wmt15 wmt16 wmt17 wmt18 wmt19
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/encs.student.tiny11/speed.cpu.sh
+++ b/csen/encs.student.tiny11/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.8bit-finetuned.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.base/config.intgemm8bit.yml
+++ b/csen/non-finetuned/csen.student.base/config.intgemm8bit.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.base/config.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/csen.student.base/config.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.base/config.yml
+++ b/csen/non-finetuned/csen.student.base/config.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.npz.best-bleu-detok.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.base/server.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/csen.student.base/server.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.base/speed.cpu.intgemm8bit.sh
+++ b/csen/non-finetuned/csen.student.base/speed.cpu.intgemm8bit.sh
@@ -14,7 +14,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.base/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/non-finetuned/csen.student.base/speed.cpu.intgemm8bitalpha.sh
@@ -12,7 +12,7 @@ mkdir -p speed
 if [ ! -f model.intgemm8.alphas.bin ]; then
 
 test -e model.npz.best-bleu-detok.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.base/speed.cpu.sh
+++ b/csen/non-finetuned/csen.student.base/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.tiny11/config.intgemm8bit.yml
+++ b/csen/non-finetuned/csen.student.tiny11/config.intgemm8bit.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.tiny11/config.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/csen.student.tiny11/config.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.tiny11/config.yml
+++ b/csen/non-finetuned/csen.student.tiny11/config.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.npz.best-bleu-detok.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.tiny11/server.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/csen.student.tiny11/server.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/csen.student.tiny11/speed.cpu.intgemm8bit.sh
+++ b/csen/non-finetuned/csen.student.tiny11/speed.cpu.intgemm8bit.sh
@@ -14,7 +14,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.tiny11/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/non-finetuned/csen.student.tiny11/speed.cpu.intgemm8bitalpha.sh
@@ -12,7 +12,7 @@ mkdir -p speed
 if [ ! -f model.intgemm8.alphas.bin ]; then
 
 test -e model.npz.best-bleu-detok.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/csen.student.tiny11/speed.cpu.sh
+++ b/csen/non-finetuned/csen.student.tiny11/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.base/config.intgemm8bit.yml
+++ b/csen/non-finetuned/encs.student.base/config.intgemm8bit.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.base/config.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/encs.student.base/config.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.base/config.yml
+++ b/csen/non-finetuned/encs.student.base/config.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.npz.best-bleu-detok.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.base/server.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/encs.student.base/server.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.base/speed.cpu.intgemm8bit.sh
+++ b/csen/non-finetuned/encs.student.base/speed.cpu.intgemm8bit.sh
@@ -14,7 +14,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.base/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/non-finetuned/encs.student.base/speed.cpu.intgemm8bitalpha.sh
@@ -12,7 +12,7 @@ mkdir -p speed
 if [ ! -f model.intgemm8.alphas.bin ]; then
 
 test -e model.npz.best-bleu-detok.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.base/speed.cpu.sh
+++ b/csen/non-finetuned/encs.student.base/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.tiny11/config.intgemm8bit.yml
+++ b/csen/non-finetuned/encs.student.tiny11/config.intgemm8bit.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.tiny11/config.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/encs.student.tiny11/config.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.tiny11/config.yml
+++ b/csen/non-finetuned/encs.student.tiny11/config.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.npz.best-bleu-detok.npz
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.tiny11/server.intgemm8bitalpha.yml
+++ b/csen/non-finetuned/encs.student.tiny11/server.intgemm8bitalpha.yml
@@ -2,8 +2,8 @@ relative-paths: true
 models:
   - model.intgemm8.alphas.bin
 vocabs:
-  - vocab.spm
-  - vocab.spm
+  - vocab.csen.spm
+  - vocab.csen.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0

--- a/csen/non-finetuned/encs.student.tiny11/speed.cpu.intgemm8bit.sh
+++ b/csen/non-finetuned/encs.student.tiny11/speed.cpu.intgemm8bit.sh
@@ -14,7 +14,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.tiny11/speed.cpu.intgemm8bitalpha.sh
+++ b/csen/non-finetuned/encs.student.tiny11/speed.cpu.intgemm8bitalpha.sh
@@ -12,7 +12,7 @@ mkdir -p speed
 if [ ! -f model.intgemm8.alphas.bin ]; then
 
 test -e model.npz.best-bleu-detok.alphas.npz || $MARIAN/marian-decoder $@ \
-    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+    --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
     -i speed/newstest2018.$SRC -o speed/cpu.newstest2018.$TRG \
     --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
     --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \
@@ -28,7 +28,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.intgemm8.alphas.bin -v vocab.spm vocab.spm \
+        --relative-paths -m model.intgemm8.alphas.bin -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/csen/non-finetuned/encs.student.tiny11/speed.cpu.sh
+++ b/csen/non-finetuned/encs.student.tiny11/speed.cpu.sh
@@ -12,7 +12,7 @@ do
     ~/.local/bin/sacrebleu -t $wmt -l $SRC-$TRG --echo src > speed/newstest.$wmt.$SRC
     echo "### Translating $wmt $SRC-$TRG on CPU"
     $MARIAN/marian-decoder $@ \
-        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.spm vocab.spm \
+        --relative-paths -m model.npz.best-bleu-detok.npz -v vocab.csen.spm vocab.csen.spm \
         -i speed/newstest.$wmt.$SRC -o speed/cpu.newstest.$wmt.$TRG \
         --beam-size 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
         --skip-cost --shortlist lex.s2t.gz 50 50 --cpu-threads 1 \

--- a/deploy.students.sh
+++ b/deploy.students.sh
@@ -9,7 +9,7 @@ for language in cs de es et is nb nn; do
   for pair in ${language}en en${language}; do
     for type in base tiny11; do
       student_model=$pair.student.$type
-      if [[ -d $student_model ]]
+      if [ -d $student_model ]
       then
         cd $student_model
         echo "Deploying $student_model"

--- a/deploy.students.sh
+++ b/deploy.students.sh
@@ -2,71 +2,22 @@
 
 set -e
 
-echo "Deploying deen..."
-cd deen/ende.student.base
-
-tar -czvf ende.student.base.tar.gz --transform 's,^,ende.student.base/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.deen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp ende.student.base.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/deen/
-
-echo "Deploying ende..."
-cd ../ende.student.tiny11
-tar -czvf ende.student.tiny11.tar.gz --transform 's,^,ende.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.deen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp ende.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/deen/
-
-echo "Deploying enet..."
-cd ../../eten/enet.student.tiny11
-
-tar -czvf enet.student.tiny11.tar.gz --transform 's,^,enet.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.eten.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp enet.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/eten/
-
-echo "Deploying eten..."
-cd ../eten.student.tiny11
-tar -czvf eten.student.tiny11.tar.gz --transform 's,^,eten.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.eten.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp eten.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/eten/
-
-echo "Deploying enes..."
-cd ../../esen/enes.student.tiny11
-tar -czvf enes.student.tiny11.tar.gz --transform 's,^,enes.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.esen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp enes.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/esen/
-
-echo "Deploying esen..."
-cd ../esen.student.tiny11
-tar -czvf esen.student.tiny11.tar.gz --transform 's,^,esen.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.esen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp esen.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/esen/
-
-echo "Deploying isen..."
-cd ../../isen/isen.student.tiny11
-tar -czvf isen.student.tiny11.tar.gz --transform 's,^,isen.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.isen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp isen.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/isen/
-
-echo "Deploying nben..."
-cd ../../nben/nben.student.tiny11
-cp ../nben.teacher.base/vocab.nben.spm ./
-tar -czvf nben.student.tiny11.tar.gz --transform 's,^,nben.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.nben.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp nben.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/nben/
-
-echo "Deploying nnen..."
-cd ../../nnen/nnen.student.tiny11
-cp ../nnen.teacher.base/vocab.nnen.spm ./
-tar -czvf nnen.student.tiny11.tar.gz --transform 's,^,nnen.student.tiny11/,' config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.nnen.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp nnen.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/nnen/
-
-echo "Deploying csen base..."
-cd ../../csen/csen.student.base
-tar -czvf csen.student.base.tar.gz --transform 's,^,csen.student.base/,' config.intgemm8bitalpha.yml model.8bit-finetuned.intgemm8.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp csen.student.base.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/csen/
-
-echo "Deploying csen tiny..."
-cd ../csen.student.tiny11
-tar -czvf csen.student.tiny11.tar.gz --transform 's,^,csen.student.tiny11/,' config.intgemm8bitalpha.yml model.8bit-finetuned.intgemm8.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp csen.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/csen/
-
-echo "Deploying encs base..."
-cd ../encs.student.base
-tar -czvf encs.student.base.tar.gz --transform 's,^,encs.student.base/,' config.intgemm8bitalpha.yml model.8bit-finetuned.intgemm8.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp encs.student.base.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/csen/
-
-echo "Deploying encs tiny..."
-cd ../encs.student.tiny11
-tar -czvf encs.student.tiny11.tar.gz --transform 's,^,encs.student.tiny11/,' config.intgemm8bitalpha.yml model.8bit-finetuned.intgemm8.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.spm catalog-entry.yml server.intgemm8bitalpha.yml
-scp encs.student.tiny11.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/csen/
+# Deploy student models
+for language in cs de es et is nb nn; do
+  dir=${language}en
+  cd $dir
+  for pair in ${language}en en${language}; do
+    for type in base tiny11; do
+      student_model=$pair.student.$type
+      if [[ -d $student_model ]]
+      then
+        cd $student_model
+        echo "Deploying $student_model"
+        tar -czvf $student_model.tar.gz --transform "s,^,${student_model}/," config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.gz lex.s2t.bin vocab.$dir.spm catalog-entry.yml server.intgemm8bitalpha.yml
+        scp $student_model.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/$dir
+        cd ..
+      fi
+    done
+  done
+  cd ..
+done


### PR DESCRIPTION
This PR fixes the naming inconsistency across different language pairs (mainly in `csen`). The consistent naming scheme allows using the `for` loop to go through all the models.