### PR TITLE
Generate sha256 checksums for entries in models.json

### DIFF
--- a/deploy.students.sh
+++ b/deploy.students.sh
@@ -19,7 +19,7 @@ for language in cs de es et is nb nn; do
         tar -czvf $student_model.tar.gz --transform "s,^,${student_model}/," config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.bin vocab.$dir.spm catalog-entry.yml model_info.json
         scp $student_model.tar.gz $USER@magni:/mnt/vali0/www/data.statmt.org/bergamot/models/$dir
         cd ..
-        ../generate_models_json.py ../models.json $student_model $dir $URLBASE
+        ../generate_models_json.py ../models.json $student_model/$student_model.tar.gz $student_model $dir $URLBASE
       fi
     done
   done

--- a/generate_models_json.py
+++ b/generate_models_json.py
@@ -2,29 +2,45 @@
 '''Meant to be called on each folder to incrementally generate a bigger json'''
 import os
 import json
+from hashlib import sha256
 from sys import argv
 
-def load_and_append(jsonin_path_models: str, model_dir: str, base_dir: str, url_prefix: str) -> None:
+
+def calc_checksum(hash_alg, path: str) -> str:
+    '''Generate hexadecimal checksum of file.'''
+    BLOCK_SIZE = 65536
+    hasher = hash_alg()
+    with open(path, 'rb') as fh:
+        while True:
+            buffer = fh.read(BLOCK_SIZE)
+            if len(buffer) == 0:
+                break
+            hasher.update(buffer)
+    return hasher.hexdigest()
+
+
+def load_and_append(jsonin_path_models: str, model_archive: str, model_dir: str, base_dir: str, url_prefix: str) -> None:
     '''Loads data from the old json file and reads some from the new model'''
     # Load existing json
     if os.path.exists(jsonin_path_models):
-        infile = open(jsonin_path_models, 'r')
-        current_json = json.load(infile)
-        infile.close()
+        with open(jsonin_path_models, 'r') as infile:
+            current_json = json.load(infile)
     else:
         current_json = {'models': []}
 
     # Load info from current file
-    inmodel = open(model_dir + '/model_info.json', 'r')
-    additional_json = json.load(inmodel)
-    inmodel.close()
+    with open(model_dir + '/model_info.json', 'r') as fh:
+        additional_json = json.load(fh)
+
+    # Generate SHA256 hash of model archive
+    additional_json["checksum"] = calc_checksum(sha256, model_archive)
 
     # Construct URL and append it to the json
     src, trg, modeltype = additional_json["shortName"].split('-')
     if modeltype == "tiny":
         modeltype = "tiny11" # The url for the tiny model contains tiny11
 
-    url = url_prefix + "/" + base_dir + "/" + src + trg + ".student." + modeltype + ".tar.gz"
+    url = url_prefix + "/" + base_dir + "/" + os.path.basename(model_archive)
     additional_json["url"] = url
 
     #include legacy namings so that we don't break the current interface
@@ -34,12 +50,11 @@ def load_and_append(jsonin_path_models: str, model_dir: str, base_dir: str, url_
     # Put it in the json and regenerate it
     current_json['models'].append(additional_json)
 
-    outfile = open(jsonin_path_models, "w")
-    json.dump(current_json, outfile, indent=4)
-    outfile.close()
+    with open(jsonin_path_models, "w") as outfile:
+        json.dump(current_json, outfile, indent=4)
 
 if __name__ == '__main__':
-    if len(argv) != 5:
-        print("Usage:", argv[0], "models.json path-to-model-dir-containing-model_info.json, model-parent-dir, url-prefix")
+    if len(argv) != 6:
+        print("Usage:", argv[0], "models.json path-to-model-archive.tar.gz path-to-model-dir-containing-model_info.json, model-parent-dir, url-prefix")
     else:
-        load_and_append(argv[1], argv[2], argv[3], argv[4])
+        load_and_append(*argv[1:])


### PR DESCRIPTION
With https://github.com/XapaJIaMnu/translateLocally/pull/49 translateLocally can now check downloads against a SHA256 checksum before attempting to extract & load them. This change adds those checksums to the generated `models.json`.

- Extended `deploy.students.sh` to pass the archive path into `generate_models_json.py`, as it needs the full path, not yjust the model_dir. The basename of this is also used for the url now, so there's no need to keep the filename pattern in sync in two places.
- Added checksum generation to generate_models_json.py
- Replaced the existing file open/close with `with` blocks because more pythonic
- Yes, the type of the `hash_alg` parameter of `calc_checksum` is missing. It would be `hash_alg: Callable[[], _hashlib.HASH]`. Unfortunately all the functions exposed by hashlib are factory functions, and the type of the object they return isn't exposed. It's a `_hashlib.HASH`, but that may be an implementation detail.