### PR TITLE
Fix chrF was accepting single reference as string

### DIFF
--- a/train-student/data/bestbleu.py
+++ b/train-student/data/bestbleu.py
@@ -96,7 +96,7 @@ def marian_best_bleu(args,score_function):
 
 def compute_chrf(references, translation):
     hypo = ' '.join(translation)
-    refs = [' '.join(r) for r in references][0]
+    refs = [' '.join(r) for r in references]
     return sacrebleu.sentence_chrf(hypo, refs).score
 
 


### PR DESCRIPTION
As https://github.com/mjpost/sacrebleu/issues/121 says, chrF was accepting single strings as reference and it shouldn't. Now it is fixed in the latest SacreBLEU version and `bestbleu.py` is complaining about it:

```
Traceback (most recent call last):
  File "bestbleu.py", line 183, in <module>
    main()
  File "bestbleu.py", line 31, in main
    marian_best_bleu(args, score_function)
  File "bestbleu.py", line 86, in marian_best_bleu
    scores = [score_function(refs, t.split()) for t in texts]
  File "bestbleu.py", line 86, in <listcomp>
    scores = [score_function(refs, t.split()) for t in texts]
  File "bestbleu.py", line 100, in compute_chrf
    return sacrebleu.sentence_chrf(hypo, refs).score
  File "/work/user/students/venv/lib/python3.7/site-packages/sacrebleu/compat.py", line 123, in sentence_chrf
    return metric.sentence_score(hypothesis, references)
  File "/work/user/students/venv/lib/python3.7/site-packages/sacrebleu/metrics/chrf.py", line 129, in sentence_score
    "sentence_score needs a list of references, not a single string"
AssertionError: sentence_score needs a list of references, not a single string
```

This PR fixes it.