### PR TITLE
Language tags

### DIFF
--- a/bgen/bgen.student.tiny11/model_info.json
+++ b/bgen/bgen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Bulgarian",
   "trg":       "English",
+  "srcTags":   {"bg": "Bulgarian"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/bgen/enbg.student.tiny11/model_info.json
+++ b/bgen/enbg.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "Bulgarian",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "bg",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/csen/csen.student.base/model_info.json
+++ b/csen/csen.student.base/model_info.json
@@ -4,6 +4,8 @@
   "type":      "base",
   "src":       "Czech",
   "trg":       "English",
+  "srcTags":   {"cs": "Czech"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/csen/csen.student.tiny11/model_info.json
+++ b/csen/csen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Czech",
   "trg":       "English",
+  "srcTags":   {"cs": "Czech"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/csen/encs.student.base/model_info.json
+++ b/csen/encs.student.base/model_info.json
@@ -4,6 +4,8 @@
   "type":      "base",
   "src":       "English",
   "trg":       "Czech",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "cs",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/csen/encs.student.tiny11/model_info.json
+++ b/csen/encs.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "Czech",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "cs",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/deen/deen.student.base/model_info.json
+++ b/deen/deen.student.base/model_info.json
@@ -4,6 +4,8 @@
   "type":      "base",
   "src":       "German",
   "trg":       "English",
+  "srcTags":   {"de": "German"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   2,
   "API":       1

--- a/deen/deen.student.tiny11/model_info.json
+++ b/deen/deen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "German",
   "trg":       "English",
+  "srcTags":   {"de": "German"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   2,
   "API":       1

--- a/deen/ende.student.base/model_info.json
+++ b/deen/ende.student.base/model_info.json
@@ -4,6 +4,8 @@
   "type":      "base",
   "src":       "English",
   "trg":       "German",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "de",
   "repository": "Bergamot",
   "version":   2,
   "API":       1

--- a/deen/ende.student.tiny11/model_info.json
+++ b/deen/ende.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "German",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "de",
   "repository": "Bergamot",
   "version":   2,
   "API":       1

--- a/enfa/enfa.student.tiny11/model_info.json
+++ b/enfa/enfa.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "Farsi",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "fa",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/esen/enes.student.tiny11/model_info.json
+++ b/esen/enes.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "Spanish",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "es",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/esen/esen.student.tiny11/model_info.json
+++ b/esen/esen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Spanish",
   "trg":       "English",
+  "srcTags":   {"es": "Spanish"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/eten/enet.student.tiny11/model_info.json
+++ b/eten/enet.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "English",
   "trg":       "Estonian",
+  "srcTags":   {"en": "English"},
+  "trgTag":    "et",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/eten/eten.student.tiny11/model_info.json
+++ b/eten/eten.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Estonian",
   "trg":       "English",
+  "srcTags":   {"et": "Estonian"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/faen/faen.student.tiny11/model_info.json
+++ b/faen/faen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Farsi",
   "trg":       "English",
+  "srcTags":   {"fa": "Farsi"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/isen/isen.student.tiny11/model_info.json
+++ b/isen/isen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Icelandic",
   "trg":       "English",
+  "srcTags":   {"is": "Icelandic"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/nben/nben.student.tiny11/model_info.json
+++ b/nben/nben.student.tiny11/model_info.json
@@ -1,8 +1,8 @@
 {
-  "modelName": "Norwegian (Bokmal)-English tiny",
+  "modelName": "Norwegian (Bokmål)-English tiny",
   "shortName": "nb-en-tiny",
   "type":      "tiny",
-  "src":       "Norwegian (Bokmal)",
+  "src":       "Norwegian (Bokmål)",
   "trg":       "English",
   "srcTags":   {"nb": "Norwegian (Bokmål)"},
   "trgTag":    "en",

--- a/nben/nben.student.tiny11/model_info.json
+++ b/nben/nben.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Norwegian (Bokmal)",
   "trg":       "English",
+  "srcTags":   {"nb": "Norwegian (Bokmål)"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1

--- a/nnen/nnen.student.tiny11/model_info.json
+++ b/nnen/nnen.student.tiny11/model_info.json
@@ -4,6 +4,8 @@
   "type":      "tiny",
   "src":       "Norwegian (Nynorsk)",
   "trg":       "English",
+  "srcTags":   {"nn": "Norwegian (Nynorsk)"},
+  "trgTag":    "en",
   "repository": "Bergamot",
   "version":   1,
   "API":       1


### PR DESCRIPTION
Add language tags explicitly to the model_info.json files.

I did not add regional tags (e.g. en-US, es-GB, es-ES) because I don't know whether the training data really was a regional English or Spanish, or just whatever cld2 identified as Spanish (which I don't think is regional). I don't expect there will be many regional specific language models, except maybe for zh-Hant, zh-Hans, etc.

I made `srcTags` a dict, with the option of adding more tags, with the idea that we might one day make models that are multilingual. At least on the input side. On the output side it would also require a different way of dealing with the model because then you have to tell it which output language you want? And that would be quite the API change on its own.

See also https://statmt.slack.com/archives/C011Z2U1MAL/p1643747001038719