### PR TITLE
deploy script: add hash and version to archive names

### DIFF
--- a/deploy.students.sh
+++ b/deploy.students.sh
@@ -31,9 +31,12 @@ for language in cs de es et is nb nn bg pl fr is hbs sl mk mt tr sq ca el uk; do
         echo "Deploying $student_model"
         rm -rf $student_model.tar.gz # Remove old model if it exists
         tar -czvf $student_model.tar.gz --transform "s,^,${student_model}/," config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.bin vocab.$dir.spm catalog-entry.yml model_info.json --owner=0 --group=0
-        scp $student_model.tar.gz $USER@lofn:/mnt/vali0/www/data.statmt.org/bergamot/models/$dir
+        hash=`sha256sum $student_model.tar.gz | cut -c 1-16`
+        frozen_archive=$student_model.$hash.tar.gz
+        mv $student_model.tar.gz $frozen_archive
+        scp $frozen_archive $USER@lofn:/mnt/vali0/www/data.statmt.org/bergamot/models/$dir
         cd ..
-        ../generate_models_json.py ../models.json $student_model/$student_model.tar.gz $student_model $dir $URLBASE
+        ../generate_models_json.py ../models.json $student_model/$frozen_archive $student_model $dir $URLBASE
       fi
     done
   done

--- a/deploy.students.sh
+++ b/deploy.students.sh
@@ -32,7 +32,8 @@ for language in cs de es et is nb nn bg pl fr is hbs sl mk mt tr sq ca el uk; do
         rm -rf $student_model.tar.gz # Remove old model if it exists
         tar -czvf $student_model.tar.gz --transform "s,^,${student_model}/," config.intgemm8bitalpha.yml model.intgemm.alphas.bin speed.cpu.intgemm8bitalpha.sh lex.s2t.bin vocab.$dir.spm catalog-entry.yml model_info.json --owner=0 --group=0
         hash=`sha256sum $student_model.tar.gz | cut -c 1-16`
-        frozen_archive=$student_model.$hash.tar.gz
+        version=`jq -r .version model_info.json`
+        frozen_archive=$student_model.v$version.$hash.tar.gz
         mv $student_model.tar.gz $frozen_archive
         scp $frozen_archive $USER@lofn:/mnt/vali0/www/data.statmt.org/bergamot/models/$dir
         cd ..


### PR DESCRIPTION
This adds the version and hash to the deployed archive names, giving each
release a new location. This avoids inconsistencies with the JSON index when it
gets out of sync.

This also allows keeping old versions around if needed.

See: https://github.com/NixOS/nixpkgs/pull/258261#discussion_r1421567171

I didn't test the changes, since I don't have deployment permissions.

CC: @XapaJIaMnu
